### PR TITLE
Fix warnings when installing python packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN mkdir -p /usr/share/man/man1 && \
 # Install app requirements first to avoid invalidating the cache
 COPY requirements.txt setup.py /app/
 WORKDIR /app
-RUN pip install --user -r requirements.txt && \
+RUN pip install --user -r requirements.txt --no-warn-script-location && \
     pip install --user entmax && \
     python -c "import nltk; nltk.download('stopwords'); nltk.download('punkt')"
 


### PR DESCRIPTION
Reproducing steps:
```
docker build -t ratsql .
```

On step 6 you get:
```
...
Installing collected packages: asdl, astor, attrs, babel, scipy, boto, python-dateutil, docutils, jmespath, botocore, s3transfer, boto3, smart-open, gensim, sentencepiece, tqdm, bpemb, cython, jsonnet, networkx, click, joblib, regex, nltk, pyrsistent, zipp, importlib-metadata, more-itertools, pyparsing, packaging, py, pluggy, pytest, tablib, docopt, SQLAlchemy, jdcal, et-xmlfile, openpyxl, records, protobuf, corenlp-protobuf, stanford-corenlp, tabulate, torch, torchtext, sacremoses, transformers, RAT-SQL
  WARNING: The script pybabel is installed in '/root/.local/bin' which is not on PATH.
  Consider adding this directory to PATH or, if you prefer to suppress this warning, use --no-warn-script-location.
  WARNING: The script tqdm is installed in '/root/.local/bin' which is not on PATH.
  Consider adding this directory to PATH or, if you prefer to suppress this warning, use --no-warn-script-location.
  WARNING: The scripts cygdb, cython and cythonize are installed in '/root/.local/bin' which is not on PATH.
  Consider adding this directory to PATH or, if you prefer to suppress this warning, use --no-warn-script-location.
  WARNING: The script nltk is installed in '/root/.local/bin' which is not on PATH.
  Consider adding this directory to PATH or, if you prefer to suppress this warning, use --no-warn-script-location.
  WARNING: The scripts py.test and pytest are installed in '/root/.local/bin' which is not on PATH.
  Consider adding this directory to PATH or, if you prefer to suppress this warning, use --no-warn-script-location.
  WARNING: The script records is installed in '/root/.local/bin' which is not on PATH.
  Consider adding this directory to PATH or, if you prefer to suppress this warning, use --no-warn-script-location.
  WARNING: The script annotate is installed in '/root/.local/bin' which is not on PATH.
  Consider adding this directory to PATH or, if you prefer to suppress this warning, use --no-warn-script-location.
  WARNING: The script tabulate is installed in '/root/.local/bin' which is not on PATH.
  Consider adding this directory to PATH or, if you prefer to suppress this warning, use --no-warn-script-location.
  WARNING: The scripts convert-caffe2-to-onnx and convert-onnx-to-caffe2 are installed in '/root/.local/bin' which is not on PATH.
  Consider adding this directory to PATH or, if you prefer to suppress this warning, use --no-warn-script-location.
  WARNING: The script sacremoses is installed in '/root/.local/bin' which is not on PATH.
  Consider adding this directory to PATH or, if you prefer to suppress this warning, use --no-warn-script-location.
  Running setup.py develop for RAT-SQL
Successfully installed RAT-SQL SQLAlchemy-1.3.18 asdl-0.1.5 astor-0.7.1 attrs-18.2.0 babel-2.7.0 boto-2.49.0 boto3-1.14.43 botocore-1.17.43 bpemb-0.2.12 click-7.1.2 corenlp-protobuf-3.8.0 cython-0.29.21 docopt-0.6.2 docutils-0.15.2 et-xmlfile-1.0.1 gensim-3.8.3 importlib-metadata-1.7.0 jdcal-1.4.1 jmespath-0.10.0 joblib-0.16.0 jsonnet-0.14.0 more-itertools-8.4.0 networkx-2.4 nltk-3.5 openpyxl-2.4.11 packaging-20.4 pluggy-0.13.1 protobuf-3.13.0 py-1.9.0 pyparsing-2.4.7 pyrsistent-0.14.11 pytest-5.3.5 python-dateutil-2.8.1 records-0.5.3 regex-2020.7.14 s3transfer-0.3.3 sacremoses-0.0.43 scipy-1.5.2 sentencepiece-0.1.91 smart-open-2.1.0 stanford-corenlp-3.9.2 tablib-2.0.0 tabulate-0.8.7 torch-1.3.1+cu92 torchtext-0.3.1 tqdm-4.36.1 transformers-2.3.0 zipp-3.1.0
...
```