### PR TITLE
Fix Stanford Core NLP - Update Docker file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ RUN python -c "from transformers import BertModel; BertModel.from_pretrained('be
 # Download & cache StanfordNLP
 RUN mkdir -p /app/third_party && \
     cd /app/third_party && \
-    curl https://nlp.stanford.edu/software/stanford-corenlp-full-2018-10-05.zip | jar xv
+    curl https://download.cs.stanford.edu/nlp/software/stanford-corenlp-full-2018-10-05.zip | jar xv
 
 # Now copy the rest of the app
 COPY . /app/


### PR DESCRIPTION
The url for the ``stanford-corenlp-full-2018-10-05`` has changed.

@See https://github.com/microsoft/rat-sql/issues/54