### PR TITLE
Fix for issue #54 & for `registry.instantiate`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN mkdir -p /usr/share/man/man1 && \
 COPY requirements.txt setup.py /app/
 WORKDIR /app
 RUN pip install --user -r requirements.txt --no-warn-script-location && \
-    pip install --user entmax && \
+    pip install --user entmax stanfordnlp && \
     python -c "import nltk; nltk.download('stopwords'); nltk.download('punkt')"
 
 # Cache the pretrained BERT model

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN mkdir -p /usr/share/man/man1 && \
 COPY requirements.txt setup.py /app/
 WORKDIR /app
 RUN pip install --user -r requirements.txt --no-warn-script-location && \
-    pip install --user entmax stanfordnlp && \
+    pip install --user entmax && \
     python -c "import nltk; nltk.download('stopwords'); nltk.download('punkt')"
 
 # Cache the pretrained BERT model

--- a/ratsql/resources/corenlp.py
+++ b/ratsql/resources/corenlp.py
@@ -1,8 +1,8 @@
 import os
 import sys
 
-import corenlp
 import requests
+from stanfordnlp.server import CoreNLPClient
 
 
 class CoreNLP:
@@ -18,7 +18,7 @@ class CoreNLP:
 
                 Direct URL: http://nlp.stanford.edu/software/stanford-corenlp-full-2018-10-05.zip
                 Landing page: https://stanfordnlp.github.io/CoreNLP/''')
-        self.client = corenlp.CoreNLPClient()
+        self.client = CoreNLPClient()
 
     def __del__(self):
         self.client.stop()

--- a/ratsql/utils/registry.py
+++ b/ratsql/utils/registry.py
@@ -36,22 +36,30 @@ def construct(kind, config, unused_keys=(), **kwargs):
             **kwargs)
 
 
-def instantiate(callable, config, unused_keys=(), **kwargs):
+def instantiate(invocable, config, unused_keys=(), **kwargs):
     merged = {**config, **kwargs}
-    signature = inspect.signature(callable)
-    for name, param in signature.parameters.items():
+    signature = inspect.signature(invocable)
+
+    if hasattr(invocable, '__init__'):
+        # to avoid inspecting ctor of parent class (if exists) instead of the target class's ctor
+        params = dict(inspect.signature(invocable.__init__).parameters)
+        params.pop('self', None)
+    else:
+        params = dict(inspect.signature(invocable).parameters)
+
+    for name, param in params.items():
         if param.kind in (inspect.Parameter.POSITIONAL_ONLY, inspect.Parameter.VAR_POSITIONAL):
             raise ValueError(f'Unsupported kind for param {name}: {param.kind}')
 
-    if any(param.kind == inspect.Parameter.VAR_KEYWORD for param in signature.parameters.values()):
-        return callable(**merged)
+    if any(param.kind == inspect.Parameter.VAR_KEYWORD for param in params.values()):
+        return invocable(**merged)
 
     missing = {}
     for key in list(merged.keys()):
-        if key not in signature.parameters:
+        if key not in params:
             if key not in unused_keys:
                 missing[key] = merged[key]
             merged.pop(key)
     if missing:
-        print(f'WARNING {callable}: superfluous {missing}', file=sys.stderr)
-    return callable(**merged)
+        print(f'WARNING {invocable}: superfluous {missing}', file=sys.stderr)
+    return invocable(**merged)

--- a/ratsql/utils/registry.py
+++ b/ratsql/utils/registry.py
@@ -38,7 +38,6 @@ def construct(kind, config, unused_keys=(), **kwargs):
 
 def instantiate(invocable, config, unused_keys=(), **kwargs):
     merged = {**config, **kwargs}
-    signature = inspect.signature(invocable)
 
     if hasattr(invocable, '__init__'):
         # to avoid inspecting ctor of parent class (if exists) instead of the target class's ctor

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
         'pyrsistent~=0.14.9',
         'pytest~=5.3.2',
         'records~=0.5.3',
-        'stanford-corenlp~=3.9.2',
+        'stanfordnlp~=0.2.0',
         'tabulate~=0.8.6',
         'torch~=1.3.1',
         'torchtext~=0.3.1',


### PR DESCRIPTION
- Fix for issue #54 
- Fix for `registry.instantiate` method, in which `inspect.signature` may call the target's parent class constructor params instead of its constructor params