### PR TITLE
Jsonnet is now platform independent (Jsonnetbin)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
         'bpemb~=0.2.11',
         'cython~=0.29.1',
         # 'entmax~=1.0',
-        'jsonnet~=0.14.0',
+        'jsonnetbin~=0.16.0',
         'networkx~=2.2',
         'nltk~=3.4',
         'numpy~=1.16',


### PR DESCRIPTION
Jsonnet doesn't work on Windows but Jsonnetbin does. 
That's why this pull request is proposed.
(https://github.com/mcovalt/jsonnetbin)