### PR TITLE
Fix dockerfile to solve CUDA Linux Repository Key Rotation issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,8 @@ FROM pytorch/pytorch:1.5-cuda10.1-cudnn7-devel
 ENV LC_ALL=C.UTF-8 \
     LANG=C.UTF-8
 
+RUN apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/3bf863cc.pub
+
 RUN mkdir -p /usr/share/man/man1 && \
     apt-get update && apt-get install -y \
     build-essential \


### PR DESCRIPTION
Solve [CUDA Linux Repsitory Key Rotatino issue](https://forums.developer.nvidia.com/t/notice-cuda-linux-repository-key-rotation/212771)
![image](https://github.com/microsoft/rat-sql/assets/37727249/a1c17fd3-9b25-4a39-af93-128ca1e1addb)


Due to issue, current Dockerfile occurs below error while building.
```
W: GPG error: https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64  InRelease: The following signatures couldn't be verified because the public key is not available: NO_PUBKEY A4B469963BF863CC
E: The repository 'https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64  InRelease' is not signed.
```